### PR TITLE
Fix SubVT GitHub link

### DIFF
--- a/docs/validate/1kv.mdx
+++ b/docs/validate/1kv.mdx
@@ -17,7 +17,7 @@ The [Thousand Validator Program](https://wiki.polkadot.network/docs/thousand-val
 | [Metaspan's 1kv overview](https://metaspan.io/kusama/candidate) | [github](https://github.com/metaspan/metaspan.io) | Up to date overview including the newly introduced endpoints, see [here](https://metaspan.io/) for available endpoints |
 | [Decentradot's 1kv overview](https://1kv.decentradot.com/) | [github](https://github.com/ccris02/1KV_API) | Up to date overview including the newly introduced endpoints |
 | [Polkachu's 1kv resources](https://polkachu.com/kusama/thousand_validators) | [github](https://github.com/polkachu) | One of the first overviews and well developed resources but has not catched up with the recent updates and has often old data |
-| SubVT telegram bot [polkadot](https://t.me/subvt_polkadot_bot) [kusama](https://t.me/subvt_kusama_bot) | [github](https://github.com/helikon-labs/polkadot-kusama-1kv-telegram-bot) | Excellent telegram bot with overviews and alerts for various polkadot and kusama related events, including 1kv events |
+| SubVT telegram bot [polkadot](https://t.me/subvt_polkadot_bot) [kusama](https://t.me/subvt_kusama_bot) | [github](https://github.com/helikon-labs/subvt-backend/tree/development/subvt-telegram-bot) | Excellent telegram bot with overviews and alerts for various polkadot and kusama related events, including 1kv events |
 | [Hirish 1kv overview](https://1k.hirish.net/polkadot) | [github?](https://github.com/) | 1KV overview |
 
 


### PR DESCRIPTION
Thanks a lot for including the SubVT bots:) Just changed the link to the repo from the deprecated 1KV bot to the SubVT bot.